### PR TITLE
"Fixed" Github Actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,5 +48,5 @@ jobs:
             ros-${ROS_DISTRO}-example-interfaces \
             ros-${ROS_DISTRO}-test-msgs
           env > "$GITHUB_ENV"
-        
-      - uses: golangci/golangci-lint-action@v6
+
+      - uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,6 +49,4 @@ jobs:
             ros-${ROS_DISTRO}-test-msgs
           env > "$GITHUB_ENV"
 
-      - uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.56.0
+      - uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,4 +47,4 @@ jobs:
             ros-${ROS_DISTRO}-test-msgs
           env > "$GITHUB_ENV"
 
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,3 +50,5 @@ jobs:
           env > "$GITHUB_ENV"
 
       - uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.56.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-    container: ros:iron
+    container: atijan/ros2-iron-golang
     env:
       GOFLAGS: -buildvcs=false
     steps:
@@ -33,7 +33,7 @@ jobs:
 
   run-linter:
     runs-on: ubuntu-latest
-    container: ros:iron
+    container: atijan/ros2-iron-golang
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,8 +34,10 @@ jobs:
   run-linter:
     runs-on: ubuntu-latest
     container: atijan/ros2-iron-golang
+    env:
+      GOFLAGS: -buildvcs=false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare environment
         shell: bash
@@ -46,5 +48,5 @@ jobs:
             ros-${ROS_DISTRO}-example-interfaces \
             ros-${ROS_DISTRO}-test-msgs
           env > "$GITHUB_ENV"
-
+        
       - uses: golangci/golangci-lint-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,8 @@ ENV CGO_CFLAGS="-I/opt/ros/${ROS_DISTRO}/include/action_msgs \
 
 ENV CGO_LDFLAGS='-L/opt/ros/${ROS_DISTRO}/lib -Wl,-rpath=/opt/ros/${ROS_DISTRO}/lib '
 
-# Set the default entrypoint
-ENTRYPOINT [ "/ros_entrypoint.sh" ]
+# Source the ros2 installation (based on the original Dockerfile: https://github.com/josegron/fog-ros-baseimage/tree/main)
+SHELL [ "/bin/bash", "-c" ]
+
+ENV BASH_ENV="/opt/ros/$ROS_DISTRO/setup.bash"
+RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> /etc/bash.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ros:iron
+
+# This is pushed to the docker hub to be accessible to the GitHub Actions
+
+# Install the golang package
+RUN apt update && apt install -y \
+  wget
+
+# Install the specific golang version
+RUN cd /tmp \
+&& wget https://go.dev/dl/go1.23.2.linux-amd64.tar.gz \
+&& tar -C /usr/local -xzf go1.23.2.linux-amd64.tar.gz
+
+ENV PATH="$PATH:/usr/local/go/bin"
+
+# Set the default entrypoint
+# ENTRYPOINT [ "/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ros:iron
+ARG ROS_DISTRO=iron
+
+FROM ros:${ROS_DISTRO}
 
 # This is pushed to the docker hub to be accessible to the GitHub Actions
 
@@ -8,10 +10,27 @@ RUN apt update && apt install -y \
 
 # Install the specific golang version
 RUN cd /tmp \
-&& wget https://go.dev/dl/go1.23.2.linux-amd64.tar.gz \
-&& tar -C /usr/local -xzf go1.23.2.linux-amd64.tar.gz
+  && wget https://go.dev/dl/go1.23.2.linux-amd64.tar.gz \
+  && tar -C /usr/local -xzf go1.23.2.linux-amd64.tar.gz
 
 ENV PATH="$PATH:/usr/local/go/bin"
+
+ENV CGO_CFLAGS="-I/opt/ros/${ROS_DISTRO}/include/action_msgs \
+  -I/opt/ros/${ROS_DISTRO}/include/builtin_interfaces \
+  -I/opt/ros/${ROS_DISTRO}/include/rcl \
+  -I/opt/ros/${ROS_DISTRO}/include/rcl_action \
+  -I/opt/ros/${ROS_DISTRO}/include/rcl_yaml_param_parser \
+  -I/opt/ros/${ROS_DISTRO}/include/rcutils \
+  -I/opt/ros/${ROS_DISTRO}/include/rmw \
+  -I/opt/ros/${ROS_DISTRO}/include/rosidl_dynamic_typesupport \
+  -I/opt/ros/${ROS_DISTRO}/include/rosidl_runtime_c \
+  -I/opt/ros/${ROS_DISTRO}/include/rosidl_typesupport_interface \
+  -I/opt/ros/${ROS_DISTRO}/include/service_msgs \
+  -I/opt/ros/${ROS_DISTRO}/include/std_msgs \
+  -I/opt/ros/${ROS_DISTRO}/include/type_description_interfaces \
+  -I/opt/ros/${ROS_DISTRO}/include/unique_identifier_msgs "
+
+ENV CGO_LDFLAGS='-L/opt/ros/${ROS_DISTRO}/lib -Wl,-rpath=/opt/ros/${ROS_DISTRO}/lib '
 
 # Set the default entrypoint
 # ENTRYPOINT [ "/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ ENV CGO_CFLAGS="-I/opt/ros/${ROS_DISTRO}/include/action_msgs \
 ENV CGO_LDFLAGS='-L/opt/ros/${ROS_DISTRO}/lib -Wl,-rpath=/opt/ros/${ROS_DISTRO}/lib '
 
 # Set the default entrypoint
-CMD [ "/ros_entrypoint.sh" ]
+ENTRYPOINT [ "/ros_entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ ENV CGO_CFLAGS="-I/opt/ros/${ROS_DISTRO}/include/action_msgs \
 ENV CGO_LDFLAGS='-L/opt/ros/${ROS_DISTRO}/lib -Wl,-rpath=/opt/ros/${ROS_DISTRO}/lib '
 
 # Set the default entrypoint
-# ENTRYPOINT [ "/bin/bash", "-c"]
+CMD [ "/ros_entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
 ARG ROS_DISTRO=iron
+# NOTE: This image is pushed to the docker hub to be accessible to the GitHub Actions
 
 FROM ros:${ROS_DISTRO}
 
-# This is pushed to the docker hub to be accessible to the GitHub Actions
-
-# Install the golang package
-RUN apt update && apt install -y \
-  wget
-
-# Install the specific golang version
-RUN cd /tmp \
-  && wget https://go.dev/dl/go1.23.2.linux-amd64.tar.gz \
-  && tar -C /usr/local -xzf go1.23.2.linux-amd64.tar.gz
+# Install the specific golang version from the official golang image
+COPY --from=golang:1.23.0-bookworm --chmod=777 /usr/local/go/ /usr/local/go/
 
 ENV PATH="$PATH:/usr/local/go/bin"
 

--- a/internal/msgs/test_msgs/action/common.gen.go
+++ b/internal/msgs/test_msgs/action/common.gen.go
@@ -13,7 +13,7 @@ package test_msgs_action
 
 /*
 #cgo LDFLAGS: "-L/usr/lib" "-Wl,-rpath=/usr/lib"
-#cgo LDFLAGS: "-L/opt/ros/humble/lib" "-Wl,-rpath=/opt/ros/humble/lib"
+#cgo LDFLAGS: "-L/opt/ros/iron/lib" "-Wl,-rpath=/opt/ros/iron/lib"
 
 #cgo LDFLAGS: -lrcl -lrosidl_runtime_c -lrosidl_typesupport_c -lrcutils -lrmw_implementation
 #cgo LDFLAGS: -ltest_msgs__rosidl_typesupport_c -ltest_msgs__rosidl_generator_c
@@ -40,23 +40,23 @@ package test_msgs_action
 
 #cgo CFLAGS: "-I/usr/include/test_msgs"
 
-#cgo CFLAGS: "-I/opt/ros/humble/include/action_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/builtin_interfaces"
-#cgo CFLAGS: "-I/opt/ros/humble/include/example_interfaces"
-#cgo CFLAGS: "-I/opt/ros/humble/include/geometry_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/rosidl_runtime_c"
-#cgo CFLAGS: "-I/opt/ros/humble/include/rosidl_typesupport_interface"
-#cgo CFLAGS: "-I/opt/ros/humble/include/sensor_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/std_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/std_srvs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/test_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/unique_identifier_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/builtin_interfaces"
+#cgo CFLAGS: "-I/opt/ros/iron/include/action_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/builtin_interfaces"
+#cgo CFLAGS: "-I/opt/ros/iron/include/example_interfaces"
+#cgo CFLAGS: "-I/opt/ros/iron/include/geometry_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/rosidl_runtime_c"
+#cgo CFLAGS: "-I/opt/ros/iron/include/rosidl_typesupport_interface"
+#cgo CFLAGS: "-I/opt/ros/iron/include/sensor_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/std_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/std_srvs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/test_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/unique_identifier_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/builtin_interfaces"
 
-#cgo CFLAGS: "-I/opt/ros/humble/include/test_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/test_msgs"
 
-#cgo CFLAGS: "-I/opt/ros/humble/include/unique_identifier_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/unique_identifier_msgs"
 
-#cgo CFLAGS: "-I/opt/ros/humble/include/test_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/test_msgs"
 */
 import "C"

--- a/internal/msgs/test_msgs/msg/common.gen.go
+++ b/internal/msgs/test_msgs/msg/common.gen.go
@@ -13,7 +13,7 @@ package test_msgs_msg
 
 /*
 #cgo LDFLAGS: "-L/usr/lib" "-Wl,-rpath=/usr/lib"
-#cgo LDFLAGS: "-L/opt/ros/humble/lib" "-Wl,-rpath=/opt/ros/humble/lib"
+#cgo LDFLAGS: "-L/opt/ros/iron/lib" "-Wl,-rpath=/opt/ros/iron/lib"
 
 #cgo LDFLAGS: -lrcl -lrosidl_runtime_c -lrosidl_typesupport_c -lrcutils -lrmw_implementation
 #cgo LDFLAGS: -ltest_msgs__rosidl_typesupport_c -ltest_msgs__rosidl_generator_c
@@ -34,19 +34,19 @@ package test_msgs_msg
 
 #cgo CFLAGS: "-I/usr/include/test_msgs"
 
-#cgo CFLAGS: "-I/opt/ros/humble/include/action_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/builtin_interfaces"
-#cgo CFLAGS: "-I/opt/ros/humble/include/example_interfaces"
-#cgo CFLAGS: "-I/opt/ros/humble/include/geometry_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/rosidl_runtime_c"
-#cgo CFLAGS: "-I/opt/ros/humble/include/rosidl_typesupport_interface"
-#cgo CFLAGS: "-I/opt/ros/humble/include/sensor_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/std_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/std_srvs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/test_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/unique_identifier_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/builtin_interfaces"
+#cgo CFLAGS: "-I/opt/ros/iron/include/action_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/builtin_interfaces"
+#cgo CFLAGS: "-I/opt/ros/iron/include/example_interfaces"
+#cgo CFLAGS: "-I/opt/ros/iron/include/geometry_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/rosidl_runtime_c"
+#cgo CFLAGS: "-I/opt/ros/iron/include/rosidl_typesupport_interface"
+#cgo CFLAGS: "-I/opt/ros/iron/include/sensor_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/std_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/std_srvs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/test_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/unique_identifier_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/builtin_interfaces"
 
-#cgo CFLAGS: "-I/opt/ros/humble/include/test_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/test_msgs"
 */
 import "C"

--- a/internal/msgs/test_msgs/srv/common.gen.go
+++ b/internal/msgs/test_msgs/srv/common.gen.go
@@ -13,7 +13,7 @@ package test_msgs_srv
 
 /*
 #cgo LDFLAGS: "-L/usr/lib" "-Wl,-rpath=/usr/lib"
-#cgo LDFLAGS: "-L/opt/ros/humble/lib" "-Wl,-rpath=/opt/ros/humble/lib"
+#cgo LDFLAGS: "-L/opt/ros/iron/lib" "-Wl,-rpath=/opt/ros/iron/lib"
 
 #cgo LDFLAGS: -lrcl -lrosidl_runtime_c -lrosidl_typesupport_c -lrcutils -lrmw_implementation
 #cgo LDFLAGS: -ltest_msgs__rosidl_typesupport_c -ltest_msgs__rosidl_generator_c
@@ -34,19 +34,19 @@ package test_msgs_srv
 
 #cgo CFLAGS: "-I/usr/include/test_msgs"
 
-#cgo CFLAGS: "-I/opt/ros/humble/include/action_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/builtin_interfaces"
-#cgo CFLAGS: "-I/opt/ros/humble/include/example_interfaces"
-#cgo CFLAGS: "-I/opt/ros/humble/include/geometry_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/rosidl_runtime_c"
-#cgo CFLAGS: "-I/opt/ros/humble/include/rosidl_typesupport_interface"
-#cgo CFLAGS: "-I/opt/ros/humble/include/sensor_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/std_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/std_srvs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/test_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/unique_identifier_msgs"
-#cgo CFLAGS: "-I/opt/ros/humble/include/test_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/action_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/builtin_interfaces"
+#cgo CFLAGS: "-I/opt/ros/iron/include/example_interfaces"
+#cgo CFLAGS: "-I/opt/ros/iron/include/geometry_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/rosidl_runtime_c"
+#cgo CFLAGS: "-I/opt/ros/iron/include/rosidl_typesupport_interface"
+#cgo CFLAGS: "-I/opt/ros/iron/include/sensor_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/std_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/std_srvs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/test_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/unique_identifier_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/test_msgs"
 
-#cgo CFLAGS: "-I/opt/ros/humble/include/test_msgs"
+#cgo CFLAGS: "-I/opt/ros/iron/include/test_msgs"
 */
 import "C"

--- a/pkg/gogen/.snapshots/gogen-TestParseROS2Field-func3-service-CancelGoal
+++ b/pkg/gogen/.snapshots/gogen-TestParseROS2Field-func3-service-CancelGoal
@@ -30,7 +30,7 @@
     },
     Constants: ([]*gogen.ROS2Constant) <nil>,
     GoImports: (map[string]string) (len=1) {
-      (string) (len=44) "github.com/tiiuae/rclgo-msgs/action_msgs/msg": (string) (len=15) "action_msgs_msg"
+      (string) (len=44) "github.com/ATIinc/rclgo-msgs/action_msgs/msg": (string) (len=15) "action_msgs_msg"
     },
     CImports: (gogen.stringSet) (len=1) {
       (string) (len=11) "action_msgs": (struct {}) {
@@ -116,7 +116,7 @@
       })
     },
     GoImports: (map[string]string) (len=1) {
-      (string) (len=44) "github.com/tiiuae/rclgo-msgs/action_msgs/msg": (string) (len=15) "action_msgs_msg"
+      (string) (len=44) "github.com/ATIinc/rclgo-msgs/action_msgs/msg": (string) (len=15) "action_msgs_msg"
     },
     CImports: (gogen.stringSet) (len=1) {
       (string) (len=11) "action_msgs": (struct {}) {

--- a/pkg/gogen/.snapshots/gogen-TestParseROS2Field-func3-service-FrameGraph
+++ b/pkg/gogen/.snapshots/gogen-TestParseROS2Field-func3-service-FrameGraph
@@ -43,7 +43,7 @@
     },
     Constants: ([]*gogen.ROS2Constant) <nil>,
     GoImports: (map[string]string) (len=1) {
-      (string) (len=44) "github.com/tiiuae/rclgo/pkg/rclgo/primitives": (string) (len=10) "primitives"
+      (string) (len=44) "github.com/ATIinc/rclgo/pkg/rclgo/primitives": (string) (len=10) "primitives"
     },
     CImports: (gogen.stringSet) {
     }

--- a/pkg/gogen/.snapshots/gogen-TestParseROS2Field-func3-service-NoResponse
+++ b/pkg/gogen/.snapshots/gogen-TestParseROS2Field-func3-service-NoResponse
@@ -30,7 +30,7 @@
     },
     Constants: ([]*gogen.ROS2Constant) <nil>,
     GoImports: (map[string]string) (len=1) {
-      (string) (len=44) "github.com/tiiuae/rclgo/pkg/rclgo/primitives": (string) (len=10) "primitives"
+      (string) (len=44) "github.com/ATIinc/rclgo/pkg/rclgo/primitives": (string) (len=10) "primitives"
     },
     CImports: (gogen.stringSet) {
     }


### PR DESCRIPTION
I created a Dockerfile that could be used for the Github Actions and pushed it to this repository as well as the built Docker Image to Docker Hub (https://hub.docker.com/repository/docker/atijan/ros2-iron-golang/general).

The Linter workflow has a number of broken dependencies and the tests need to have the snapshots updated.

Wondering how much effort should still be put into this. From what I can tell, updating the snapshots are pretty straight-forward.