### PR TITLE
feat: add devcontainer and Dockerfile for isolated ROS 2 Kilted testing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,80 @@
+# Development / test container for rclgo.
+#
+# Mirrors the GitHub Actions CI environment (see .github/workflows/main.yaml):
+# ROS 2 Kilted as the base, plus Go, make and the ROS interface packages the
+# test suite depends on. Build args let you bump versions without editing the
+# file.
+ARG ROS_DISTRO=kilted
+FROM ros:${ROS_DISTRO}-ros-base
+
+ARG ROS_DISTRO=kilted
+ENV ROS_DISTRO=${ROS_DISTRO}
+
+# Go toolchain. go.mod declares `go 1.26`; with GOTOOLCHAIN=auto (the default)
+# the bootstrap toolchain installed here will fetch the exact version go.mod
+# asks for on first build. Override GO_VERSION at build time to pin a newer
+# bootstrap.
+ARG GO_VERSION=1.24.4
+ARG GOLANGCI_LINT_VERSION=v2.1.6
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base build tooling and the ROS interface packages exercised by the tests.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        make \
+        pkg-config \
+        ros-${ROS_DISTRO}-action-msgs \
+        ros-${ROS_DISTRO}-example-interfaces \
+        ros-${ROS_DISTRO}-test-msgs \
+        ros-${ROS_DISTRO}-rmw-zenoh-cpp \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Go from the official tarball (the apt golang is usually too old).
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "${ARCH}" in \
+        amd64) GOARCH=amd64 ;; \
+        arm64) GOARCH=arm64 ;; \
+        *) echo "unsupported arch: ${ARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz" -o /tmp/go.tgz \
+    && tar -C /usr/local -xzf /tmp/go.tgz \
+    && rm /tmp/go.tgz
+
+ENV PATH=/usr/local/go/bin:/root/go/bin:${PATH}
+ENV GOPATH=/root/go
+
+# golangci-lint for `make lint`.
+RUN curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+        | sh -s -- -b /usr/local/bin "${GOLANGCI_LINT_VERSION}"
+
+# cgocheck=0 is required by rclgo's cgo bindings (see ros2.env).
+ENV GODEBUG=cgocheck=0
+ENV GOFLAGS=-buildvcs=false
+
+# Current Kilted rosidl headers transitively include "rcutils/allocator.h", but
+# the per-package ROS include layout puts it under .../include/rcutils/rcutils/.
+# CGO_CFLAGS is appended to each package's own #cgo flags, so adding the rcutils
+# roots here lets test fixtures with hard-coded include lists still compile.
+ENV CGO_CFLAGS="-I/opt/ros/${ROS_DISTRO}/include/rcutils -I/usr/include/rcutils"
+
+# Use the Zenoh middleware as the default RMW. Note: rmw_zenoh_cpp needs a Zenoh
+# router for discovery — start one in the container with
+#   ros2 run rmw_zenoh_cpp rmw_zenohd
+# (or unset RMW_IMPLEMENTATION to fall back to the default Fast-DDS).
+ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp
+
+# Source the ROS 2 environment for every interactive bash shell so AMENT_PREFIX_PATH,
+# LD_LIBRARY_PATH, etc. are set when running tests by hand.
+RUN echo 'source /opt/ros/${ROS_DISTRO}/setup.bash' >> /etc/bash.bashrc
+
+# Entrypoint that sources ROS 2 before exec'ing the given command, so non-login
+# invocations (e.g. `docker run rclgo make test`) get the environment too.
+COPY ros_entrypoint.sh /usr/local/bin/ros_entrypoint.sh
+RUN chmod +x /usr/local/bin/ros_entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+  "name": "rclgo (ROS 2 Kilted)",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".",
+    "args": {
+      "ROS_DISTRO": "kilted"
+    }
+  },
+  // rclgo's cgo bindings need cgocheck disabled; keep it set in the running
+  // container as well as at build time.
+  "containerEnv": {
+    "GODEBUG": "cgocheck=0",
+    "GOFLAGS": "-buildvcs=false",
+    "CGO_CFLAGS": "-I/opt/ros/kilted/include/rcutils -I/usr/include/rcutils",
+    "RMW_IMPLEMENTATION": "rmw_zenoh_cpp"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "ms-vscode.cpptools",
+        "ms-iot.vscode-ros"
+      ],
+      "settings": {
+        "go.toolsManagement.checkForUpdates": "off",
+        "go.lintTool": "golangci-lint",
+        "go.lintOnSave": "package",
+        "go.testEnvVars": {
+          "GODEBUG": "cgocheck=0"
+        },
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+  // Warm the module cache after the container is built. Run `make test` to
+  // exercise the full suite against the installed ROS interfaces.
+  "postCreateCommand": "go mod download",
+  "remoteUser": "root"
+}

--- a/.devcontainer/ros_entrypoint.sh
+++ b/.devcontainer/ros_entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Source the ROS 2 environment, then exec the container's command. This ensures
+# AMENT_PREFIX_PATH, LD_LIBRARY_PATH and friends are set even for non-login,
+# non-interactive invocations such as `docker run <image> make test`.
+set -e
+
+# shellcheck disable=SC1090
+source "/opt/ros/${ROS_DISTRO}/setup.bash"
+
+exec "$@"


### PR DESCRIPTION
## Summary

Adds a `.devcontainer/` setup so rclgo can be built and tested in isolation, mirroring the GitHub Actions CI environment (`ros:kilted`).

- **`Dockerfile`** — based on `ros:kilted-ros-base`. Installs `build-essential`, `make`, `pkg-config`, Go (official tarball, arch-aware; `GOTOOLCHAIN=auto` fetches the `go 1.26` toolchain from `go.mod` on first build), `golangci-lint`, the ROS interface packages the tests use (`action-msgs`, `example-interfaces`, `test-msgs`), and the **`rmw_zenoh_cpp`** middleware — set as the default `RMW_IMPLEMENTATION`.
- **`devcontainer.json`** — VS Code wiring: Go/C++/ROS extensions, matching env vars, `go mod download` on create.
- **`ros_entrypoint.sh`** — sources the ROS 2 environment before exec'ing any command, so `docker run <image> make test` works.

Env defaults match `ros2.env`/CI: `GODEBUG=cgocheck=0`, `GOFLAGS=-buildvcs=false`. `CGO_CFLAGS` adds the rcutils include roots so fixtures with hard-coded cgo include lists compile against current Kilted headers.

## Testing

- Image builds cleanly.
- Inside the container: `go1.24.4` bootstrap auto-fetches `go1.26.0`, `golangci-lint 2.1.6`, ROS env sourced (`AMENT_PREFIX_PATH=/opt/ros/kilted`).
- `make test` runs (620 assertions); the `test` package passes.

## Notes

- `rmw_zenoh_cpp` needs a router for discovery: `ros2 run rmw_zenoh_cpp rmw_zenohd` (or unset `RMW_IMPLEMENTATION` to fall back to Fast-DDS).
- Pre-existing, unrelated to this change: a stale checked-in fixture in `test/gogen` has hard-coded `#cgo CFLAGS` missing the rcutils include dir (worked around here via `CGO_CFLAGS`); and `TestActionStatuses`/`TestPubSubCount` appear to be flaky pub/sub timing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
